### PR TITLE
Fix parametro vacio

### DIFF
--- a/app/lib/Core.php
+++ b/app/lib/Core.php
@@ -29,8 +29,8 @@ class Core
       }
     }
 
-    $this->parameters = $url ? array_values($url) : [];
-    call_user_func_array([$this->controller, $this->method], $this->parameters);
+    $this->parameters = $url ? $url : [];
+    call_user_func_array([$this->controller, $this->method], [$this->parameters]);
   }
 
   public function getUrl()


### PR DESCRIPTION
Cuando el metodo de destino indica que debe incorporarse un parametro pero no se le envió muestra un error. por ejemplo si en la pagina se escribe "/usuario/" en lugar de "/usuario/giancarlo" muestra un error en el call_user_func_array, este cambio evita este error