### PR TITLE
Validar parametro vacio

### DIFF
--- a/app/controllers/Views.php
+++ b/app/controllers/Views.php
@@ -13,7 +13,11 @@ class Views extends Control
 
   public function update($id)
   {
-    echo "Update view " . $id;
+     if(empty($id)){
+            exit("No se estableció el parametro 'id'");
+        }else{
+            echo $id[2];
+        }
   }
 
 }


### PR DESCRIPTION
si se llama al metodo con el parametro $id vacio, mostraba error, este cambio hará que valide y muestre el mensaje